### PR TITLE
feature/kakaoLogin

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+VITE_KAKAO_REST_API_KEY=a62fd5de8b952ac37beaf4edcb5980fa
+
+VITE_KAKAO_REDIRECT_URI=http://localhost:5173/kakao/redirection
+VITE_KAKAO_REDIRECT_URI=http://192.168.209.4:4173/kakao/redirection

--- a/src/pages/kakao/login.tsx
+++ b/src/pages/kakao/login.tsx
@@ -2,8 +2,9 @@ import pullLogo from "../../assets/fullLogo.svg";
 import kakaoLogin from "../../assets/kakao_login_large_wide.png";
 
 export default function Login() {
-  const REST_API_KEY = "a62fd5de8b952ac37beaf4edcb5980fa";
-  const REDIRECT_URI = "http://localhost:5173/kakao/redirection";
+  const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+  const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
   const link = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
   const loginHandler = () => {

--- a/src/pages/kakao/redirection.tsx
+++ b/src/pages/kakao/redirection.tsx
@@ -33,5 +33,5 @@ export default function Redirection() {
     // sendCode();
     navigate("/select/crop");
   }, []);
-  return <div>hi</div>;
+  return;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

[NYM-39]

## 📝작업 내용

- 카카오 로그인 구현
- 카카오 로그인 성공 시 redirect URI 은 <Redirection />으로 함.
- 인증 번호를 백엔드로 전송 후 200이면 main으로 이동
- 추가 작업이 필요할 것 같음(토큰 관리, 백엔드와 통신 등)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
